### PR TITLE
env.DO C KERHUB_PAT (com espaços) em vez de env.DOCKERHUB_PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DO C KERHUB_PAT }}
+          password: ${{ env.DOCKERHUB_PAT }}   # <— sem espaços aqui
 
       - name: Skip push (secret ausente)
         if: ${{ env.DOCKERHUB_PAT == '' }}


### PR DESCRIPTION
env.DO C KERHUB_PAT (com espaços) em vez de env.DOCKERHUB_PAT